### PR TITLE
Fix links to dist and lib in empty_project.html

### DIFF
--- a/examples/empty_project.html
+++ b/examples/empty_project.html
@@ -5,8 +5,8 @@
 -->
 
 <html>
-<script src="../../dist/cacatoo.js"></script> <!-- Include cacatoo library (compiled with rollup) -->
-<script src="../../lib/all.js"></script> <!-- Include other libraries (concattenated in 1 file) -->
+<script src="../dist/cacatoo.js"></script> <!-- Include cacatoo library (compiled with rollup) -->
+<script src="../lib/all.js"></script> <!-- Include other libraries (concattenated in 1 file) -->
 <link rel="stylesheet" href="../../style/cacatoo.css"> <!-- Set style sheet -->
 
 <head>


### PR DESCRIPTION
The links were nested one folder too deep, they were the same as e.g. the beginner examples. I removed a nesting level in this file and it can now follow the links (tested by clicking on links in VSCode script).